### PR TITLE
added navigation options to remove the header from home and client page

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -217,19 +217,28 @@ export default class HomeScreen extends Component {
       </View>
     );
   }
-}
+} // end of HomeScreen
 
 /* CUSTOM ROUTE BELOW */
 const SuperMarketApp = StackNavigator({
   Home: {
-    screen: HomeScreen
+    screen: HomeScreen,
+    navigationOptions: {
+        header: null
+    },
   },
   ClientScreen: {
-    screen: ClientScreen
+    screen: ClientScreen,
+    navigationOptions: {
+        header: null
+    },
   },
   ReceiverScreen: {
-    screen: ReceiverScreen
-  }
+    screen: ReceiverScreen,
+    navigationOptions: {
+        header: null
+     },
+    },
 });
 
 AppRegistry.registerComponent('SuperMarketApp', () => SuperMarketApp);


### PR DESCRIPTION
Looks like there is a new way with removing the top navigation. This has been updated and didn't crash my device when I re-installed it.